### PR TITLE
feat(slides): Allow reveal.js configuration from notebook metadata

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -183,3 +183,35 @@ class SlidesExporter(HTMLExporter):
         resources["reveal"]["scroll"] = self.reveal_scroll
         resources["reveal"]["number"] = self.reveal_number
         return resources
+    
+    def from_notebook_node(self, nb, resources=None, **kw):
+        """
+        Convert a notebook from a notebook node instance.
+        This method extends the parent implementation to override reveal.js
+        configuration with metadata from the notebook.
+        It reads reveal.js settings from the `reveal` key in the notebook's
+        metadata and merges them with the existing configuration.
+        The precedence for settings is:
+        1. Command-line arguments (highest)
+        2. Notebook metadata
+        3. Default configuration (lowest)
+        Parameters
+        ----------
+        nb : :class:`~nbformat.NotebookNode`
+            Notebook node
+        resources : dict
+            Additional resources that can be accessed by exporters and preprocessors.
+        """
+        output, resources = super().from_notebook_node(nb, resources, **kw)
+        if "reveal" in nb.metadata:
+            self.log.info("Applying reveal config from notebook metadata")
+            # Get reveal config from notebook metadata.
+            nb_reveal_config = nb.metadata.get("reveal", {})
+
+            # `resources['reveal']` contains config from command line.
+            # We merge the two, with command-line config having precedence.
+            reveal_config = nb_reveal_config.copy()
+            reveal_config.update(resources.get("reveal", {}))
+            resources["reveal"] = reveal_config
+
+        return output, resources


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows `reveal.js` presentation settings to be configured directly within a notebook's metadata.

Currently, `reveal.js` options for slide exports are primarily set via command-line arguments or configuration files. This separates the presentation's configuration from its content, making it less portable. For example, if a user wants to share a notebook that is designed to be presented with a specific theme or transition, they must also share the command-line flags needed to reproduce it.

This enhancement allows users to embed `reveal.js` settings within the `.ipynb` file itself, making presentations self-contained and easier to share and reproduce consistently.

## Implementation Details

The feature is implemented by overriding the `from_notebook_node` method in the `SlidesExporter`. The new implementation preserves the existing conversion logic by first calling `super().from_notebook_node()`. It then inspects the notebook's metadata for a `reveal` key and merges the settings with the configuration already loaded from command-line options and defaults.

A clear order of precedence is maintained to ensure intuitive and predictable behavior:
1.  **Command-line arguments** (e.g., `--SlidesExporter.reveal_theme=night`) have the highest priority.
2.  **Notebook metadata** is applied next.
3.  **Exporter defaults** are used as the base (lowest priority).

This ensures that users can set project-wide defaults in a notebook but still easily override them from the command line for a specific export.

## How to Use

To use this feature, a user can edit the notebook's metadata (e.g., in Jupyter, via `Edit > Edit Notebook Metadata`) and add a `reveal` object.

**Example Notebook Metadata:**
```json
{
  "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
  },
  "language_info": {
    "name": "python",
    "version": "3.9.7"
  },
  "reveal": {
    "theme": "sky",
    "transition": "zoom",
    "scroll": true
  }
}
```

When a notebook with this metadata is exported using `jupyter nbconvert --to slides`, it will automatically use the "sky" theme and "zoom" transition, unless a different value is provided on the command line.

---